### PR TITLE
Allow iOS background updates when terminated

### DIFF
--- a/ios/Classes/SwiftBackgroundLocationPlugin.swift
+++ b/ios/Classes/SwiftBackgroundLocationPlugin.swift
@@ -21,6 +21,7 @@ public class SwiftBackgroundLocationPlugin: NSObject, FlutterPlugin, CLLocationM
             SwiftBackgroundLocationPlugin.locationManager = CLLocationManager()
             SwiftBackgroundLocationPlugin.locationManager?.delegate = self
             SwiftBackgroundLocationPlugin.locationManager?.requestAlwaysAuthorization()
+            SwiftBackgroundLocationPlugin.locationManager?.startMonitoringSignificantLocationChanges()
 
             SwiftBackgroundLocationPlugin.locationManager?.allowsBackgroundLocationUpdates = true
             if #available(iOS 11.0, *) {


### PR DESCRIPTION
This PR enables the ability for the app to be woken up and trigger the callback even when terminated once iOS detects a significant location change (200 - 500 meters). Tested and working.

- 'background_location\ios\Classes\SwiftBackgroundLocationPlugin.swift' = Added lines
```swift
24 SwiftBackgroundLocationPlugin.locationManager?.startMonitoringSignificantLocationChanges()
```